### PR TITLE
Update base loot tables to patched vanilla 1.20.5

### DIFF
--- a/ltos/data/minecraft/loot_tables/blocks/acacia_button.json
+++ b/ltos/data/minecraft/loot_tables/blocks/acacia_button.json
@@ -2,19 +2,19 @@
     "type": "minecraft:block",
     "pools": [
         {
-            "rolls": 1,
-            "bonus_rolls": 0,
+            "bonus_rolls": 0.0,
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ],
             "entries": [
                 {
                     "type": "minecraft:item",
                     "name": "minecraft:acacia_button"
                 }
             ],
-            "conditions": [
-                {
-                    "condition": "minecraft:survives_explosion"
-                }
-            ]
+            "rolls": 1.0
         },
         {
             "rolls": 1,

--- a/ltos/data/minecraft/loot_tables/blocks/acacia_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/acacia_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
@@ -74,22 +74,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/ltos/data/minecraft/loot_tables/blocks/amethyst_cluster.json
+++ b/ltos/data/minecraft/loot_tables/blocks/amethyst_cluster.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],
@@ -35,7 +37,7 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "tag": "minecraft:cluster_max_harvestables"
+                                                "items": "#minecraft:cluster_max_harvestables"
                                             }
                                         }
                                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/azalea_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/azalea_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
@@ -74,22 +74,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/ltos/data/minecraft/loot_tables/blocks/barrel.json
+++ b/ltos/data/minecraft/loot_tables/blocks/barrel.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/beacon.json
+++ b/ltos/data/minecraft/loot_tables/blocks/beacon.json
@@ -8,7 +8,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/bee_nest.json
+++ b/ltos/data/minecraft/loot_tables/blocks/bee_nest.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],
@@ -23,13 +25,9 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Bees",
-                                    "target": "BlockEntityTag.Bees"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:bees"
                             ],
                             "source": "block_entity"
                         },

--- a/ltos/data/minecraft/loot_tables/blocks/beehive.json
+++ b/ltos/data/minecraft/loot_tables/blocks/beehive.json
@@ -13,26 +13,24 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],
                             "functions": [
                                 {
-                                    "function": "minecraft:copy_custom_data",
-                                    "ops": [
-                                        {
-                                            "op": "replace",
-                                            "source": "Bees",
-                                            "target": "BlockEntityTag.Bees"
-                                        }
+                                    "function": "minecraft:copy_components",
+                                    "include": [
+                                        "minecraft:bees"
                                     ],
                                     "source": "block_entity"
                                 },

--- a/ltos/data/minecraft/loot_tables/blocks/birch_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/birch_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
@@ -74,22 +74,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/ltos/data/minecraft/loot_tables/blocks/black_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/black_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/black_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/black_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:black_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/black_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/black_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/black_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/black_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/blast_furnace.json
+++ b/ltos/data/minecraft/loot_tables/blocks/blast_furnace.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/blue_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/blue_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/blue_ice.json
+++ b/ltos/data/minecraft/loot_tables/blocks/blue_ice.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/blue_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/blue_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:blue_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/blue_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/blue_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/blue_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/blue_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/bookshelf.json
+++ b/ltos/data/minecraft/loot_tables/blocks/bookshelf.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/brain_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/brain_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/brain_coral_block.json
+++ b/ltos/data/minecraft/loot_tables/blocks/brain_coral_block.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/brain_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/brain_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/brewing_stand.json
+++ b/ltos/data/minecraft/loot_tables/blocks/brewing_stand.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/brown_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/brown_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/brown_mushroom_block.json
+++ b/ltos/data/minecraft/loot_tables/blocks/brown_mushroom_block.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/brown_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/brown_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:brown_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/brown_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/brown_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/brown_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/brown_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/bubble_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/bubble_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/bubble_coral_block.json
+++ b/ltos/data/minecraft/loot_tables/blocks/bubble_coral_block.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/bubble_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/bubble_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/calibrated_sculk_sensor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/calibrated_sculk_sensor.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/campfire.json
+++ b/ltos/data/minecraft/loot_tables/blocks/campfire.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/cherry_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/cherry_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
@@ -74,22 +74,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/ltos/data/minecraft/loot_tables/blocks/chest.json
+++ b/ltos/data/minecraft/loot_tables/blocks/chest.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/chiseled_bookshelf.json
+++ b/ltos/data/minecraft/loot_tables/blocks/chiseled_bookshelf.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/chiseled_copper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/chiseled_copper",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'chiseled_copper'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/chiseled_tuff.json
+++ b/ltos/data/minecraft/loot_tables/blocks/chiseled_tuff.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/chiseled_tuff",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'chiseled_tuff'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/chiseled_tuff_bricks.json
+++ b/ltos/data/minecraft/loot_tables/blocks/chiseled_tuff_bricks.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/chiseled_tuff_bricks",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'chiseled_tuff_bricks'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/clay.json
+++ b/ltos/data/minecraft/loot_tables/blocks/clay.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/coal_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/coal_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/cobweb.json
+++ b/ltos/data/minecraft/loot_tables/blocks/cobweb.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]

--- a/ltos/data/minecraft/loot_tables/blocks/copper_bulb.json
+++ b/ltos/data/minecraft/loot_tables/blocks/copper_bulb.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/copper_bulb",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'copper_bulb'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/copper_door.json
+++ b/ltos/data/minecraft/loot_tables/blocks/copper_door.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/copper_door",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'copper_door'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/copper_grate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/copper_grate.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/copper_grate",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'copper_grate'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/copper_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/copper_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/copper_trapdoor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/copper_trapdoor",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'copper_trapdoor'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/crafter.json
+++ b/ltos/data/minecraft/loot_tables/blocks/crafter.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/crafter",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'crafter'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/crimson_nylium.json
+++ b/ltos/data/minecraft/loot_tables/blocks/crimson_nylium.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/cyan_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/cyan_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/cyan_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/cyan_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:cyan_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/cyan_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/cyan_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/cyan_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/cyan_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dark_oak_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dark_oak_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
@@ -74,22 +74,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]
@@ -142,22 +142,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/ltos/data/minecraft/loot_tables/blocks/dead_brain_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_brain_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_brain_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_brain_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_bubble_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_bubble_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_bubble_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_bubble_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_bush.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_bush.json
@@ -13,9 +13,7 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "items": [
-                                            "minecraft:shears"
-                                        ]
+                                        "items": "minecraft:shears"
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_fire_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_fire_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_fire_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_fire_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_horn_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_horn_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_horn_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_horn_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_tube_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_tube_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dead_tube_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dead_tube_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/decorated_pot.json
+++ b/ltos/data/minecraft/loot_tables/blocks/decorated_pot.json
@@ -11,25 +11,10 @@
                             "type": "minecraft:dynamic",
                             "conditions": [
                                 {
-                                    "condition": "minecraft:match_tool",
-                                    "predicate": {
-                                        "tag": "minecraft:breaks_decorated_pots"
-                                    }
-                                },
-                                {
-                                    "condition": "minecraft:inverted",
-                                    "term": {
-                                        "condition": "minecraft:match_tool",
-                                        "predicate": {
-                                            "enchantments": [
-                                                {
-                                                    "enchantment": "minecraft:silk_touch",
-                                                    "levels": {
-                                                        "min": 1
-                                                    }
-                                                }
-                                            ]
-                                        }
+                                    "block": "minecraft:decorated_pot",
+                                    "condition": "minecraft:block_state_property",
+                                    "properties": {
+                                        "cracked": "true"
                                     }
                                 }
                             ],
@@ -39,13 +24,9 @@
                             "type": "minecraft:item",
                             "functions": [
                                 {
-                                    "function": "minecraft:copy_custom_data",
-                                    "ops": [
-                                        {
-                                            "op": "replace",
-                                            "source": "sherds",
-                                            "target": "BlockEntityTag.sherds"
-                                        }
+                                    "function": "minecraft:copy_components",
+                                    "include": [
+                                        "minecraft:pot_decorations"
                                     ],
                                     "source": "block_entity"
                                 }

--- a/ltos/data/minecraft/loot_tables/blocks/deepslate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/deepslate.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/deepslate_coal_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/deepslate_coal_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/deepslate_copper_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/deepslate_copper_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/deepslate_diamond_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/deepslate_diamond_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/deepslate_emerald_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/deepslate_emerald_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/deepslate_gold_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/deepslate_gold_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/deepslate_iron_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/deepslate_iron_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/deepslate_lapis_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/deepslate_lapis_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/deepslate_redstone_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/deepslate_redstone_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/diamond_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/diamond_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/dispenser.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dispenser.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/dropper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/dropper.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/emerald_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/emerald_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/enchanting_table.json
+++ b/ltos/data/minecraft/loot_tables/blocks/enchanting_table.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/ender_chest.json
+++ b/ltos/data/minecraft/loot_tables/blocks/ender_chest.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/exposed_chiseled_copper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/exposed_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/exposed_chiseled_copper",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'exposed_chiseled_copper'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/exposed_copper_bulb.json
+++ b/ltos/data/minecraft/loot_tables/blocks/exposed_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/exposed_copper_bulb",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'exposed_copper_bulb'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/exposed_copper_door.json
+++ b/ltos/data/minecraft/loot_tables/blocks/exposed_copper_door.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/exposed_copper_door",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'exposed_copper_door'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/exposed_copper_grate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/exposed_copper_grate.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/exposed_copper_grate",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'exposed_copper_grate'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/exposed_copper_trapdoor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/exposed_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/exposed_copper_trapdoor",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'exposed_copper_trapdoor'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/fern.json
+++ b/ltos/data/minecraft/loot_tables/blocks/fern.json
@@ -13,9 +13,7 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "items": [
-                                            "minecraft:shears"
-                                        ]
+                                        "items": "minecraft:shears"
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/fire_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/fire_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/fire_coral_block.json
+++ b/ltos/data/minecraft/loot_tables/blocks/fire_coral_block.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/fire_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/fire_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/flowering_azalea_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/flowering_azalea_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
@@ -74,22 +74,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/ltos/data/minecraft/loot_tables/blocks/furnace.json
+++ b/ltos/data/minecraft/loot_tables/blocks/furnace.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/gilded_blackstone.json
+++ b/ltos/data/minecraft/loot_tables/blocks/gilded_blackstone.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/glow_lichen.json
+++ b/ltos/data/minecraft/loot_tables/blocks/glow_lichen.json
@@ -10,9 +10,7 @@
                         {
                             "condition": "minecraft:match_tool",
                             "predicate": {
-                                "items": [
-                                    "minecraft:shears"
-                                ]
+                                "items": "minecraft:shears"
                             }
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/glowstone.json
+++ b/ltos/data/minecraft/loot_tables/blocks/glowstone.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/gold_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/gold_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/grass_block.json
+++ b/ltos/data/minecraft/loot_tables/blocks/grass_block.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/gravel.json
+++ b/ltos/data/minecraft/loot_tables/blocks/gravel.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/gray_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/gray_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/gray_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/gray_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:gray_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/gray_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/gray_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/gray_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/gray_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/green_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/green_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/green_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/green_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:green_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/green_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/green_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/green_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/green_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/hanging_roots.json
+++ b/ltos/data/minecraft/loot_tables/blocks/hanging_roots.json
@@ -7,9 +7,7 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "items": [
-                            "minecraft:shears"
-                        ]
+                        "items": "minecraft:shears"
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/heavy_core.json
+++ b/ltos/data/minecraft/loot_tables/blocks/heavy_core.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/heavy_core",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'heavy_core'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/hopper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/hopper.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/horn_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/horn_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/horn_coral_block.json
+++ b/ltos/data/minecraft/loot_tables/blocks/horn_coral_block.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/horn_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/horn_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/ice.json
+++ b/ltos/data/minecraft/loot_tables/blocks/ice.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/infested_chiseled_stone_bricks.json
+++ b/ltos/data/minecraft/loot_tables/blocks/infested_chiseled_stone_bricks.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/infested_cobblestone.json
+++ b/ltos/data/minecraft/loot_tables/blocks/infested_cobblestone.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/infested_cracked_stone_bricks.json
+++ b/ltos/data/minecraft/loot_tables/blocks/infested_cracked_stone_bricks.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/infested_deepslate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/infested_deepslate.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/infested_mossy_stone_bricks.json
+++ b/ltos/data/minecraft/loot_tables/blocks/infested_mossy_stone_bricks.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/infested_stone.json
+++ b/ltos/data/minecraft/loot_tables/blocks/infested_stone.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/infested_stone_bricks.json
+++ b/ltos/data/minecraft/loot_tables/blocks/infested_stone_bricks.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/iron_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/iron_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/jungle_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/jungle_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
@@ -75,22 +75,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/ltos/data/minecraft/loot_tables/blocks/lapis_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/lapis_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/large_amethyst_bud.json
+++ b/ltos/data/minecraft/loot_tables/blocks/large_amethyst_bud.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/large_fern.json
+++ b/ltos/data/minecraft/loot_tables/blocks/large_fern.json
@@ -16,9 +16,7 @@
                     "offsetY": 1,
                     "predicate": {
                         "block": {
-                            "blocks": [
-                                "minecraft:large_fern"
-                            ],
+                            "blocks": "minecraft:large_fern",
                             "state": {
                                 "half": "upper"
                             }
@@ -36,9 +34,7 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "items": [
-                                            "minecraft:shears"
-                                        ]
+                                        "items": "minecraft:shears"
                                     }
                                 }
                             ],
@@ -84,9 +80,7 @@
                     "offsetY": -1,
                     "predicate": {
                         "block": {
-                            "blocks": [
-                                "minecraft:large_fern"
-                            ],
+                            "blocks": "minecraft:large_fern",
                             "state": {
                                 "half": "lower"
                             }
@@ -104,9 +98,7 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "items": [
-                                            "minecraft:shears"
-                                        ]
+                                        "items": "minecraft:shears"
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/light_blue_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/light_blue_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/light_blue_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/light_blue_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:light_blue_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/light_blue_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/light_blue_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/light_blue_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/light_blue_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/light_gray_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/light_gray_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/light_gray_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/light_gray_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:light_gray_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/light_gray_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/light_gray_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/light_gray_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/light_gray_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/lime_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/lime_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/lime_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/lime_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:lime_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/lime_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/lime_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/lime_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/lime_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/magenta_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/magenta_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/magenta_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/magenta_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:magenta_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/magenta_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/magenta_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/magenta_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/magenta_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/mangrove_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/mangrove_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]

--- a/ltos/data/minecraft/loot_tables/blocks/medium_amethyst_bud.json
+++ b/ltos/data/minecraft/loot_tables/blocks/medium_amethyst_bud.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/melon.json
+++ b/ltos/data/minecraft/loot_tables/blocks/melon.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/mushroom_stem.json
+++ b/ltos/data/minecraft/loot_tables/blocks/mushroom_stem.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/mycelium.json
+++ b/ltos/data/minecraft/loot_tables/blocks/mycelium.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/nether_gold_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/nether_gold_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/nether_quartz_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/nether_quartz_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/nether_sprouts.json
+++ b/ltos/data/minecraft/loot_tables/blocks/nether_sprouts.json
@@ -7,9 +7,7 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "items": [
-                            "minecraft:shears"
-                        ]
+                        "items": "minecraft:shears"
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/oak_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/oak_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
@@ -74,22 +74,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]
@@ -142,22 +142,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/ltos/data/minecraft/loot_tables/blocks/orange_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/orange_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/orange_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/orange_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:orange_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/orange_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/orange_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/orange_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/orange_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/oxidized_chiseled_copper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/oxidized_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/oxidized_chiseled_copper",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'oxidized_chiseled_copper'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/oxidized_copper_bulb.json
+++ b/ltos/data/minecraft/loot_tables/blocks/oxidized_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/oxidized_copper_bulb",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'oxidized_copper_bulb'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/oxidized_copper_door.json
+++ b/ltos/data/minecraft/loot_tables/blocks/oxidized_copper_door.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/oxidized_copper_door",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'oxidized_copper_door'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/oxidized_copper_grate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/oxidized_copper_grate.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/oxidized_copper_grate",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'oxidized_copper_grate'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/oxidized_copper_trapdoor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/oxidized_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/oxidized_copper_trapdoor",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'oxidized_copper_trapdoor'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/packed_ice.json
+++ b/ltos/data/minecraft/loot_tables/blocks/packed_ice.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/pink_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/pink_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/pink_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/pink_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:pink_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/pink_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/pink_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/pink_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/pink_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/player_head.json
+++ b/ltos/data/minecraft/loot_tables/blocks/player_head.json
@@ -8,18 +8,11 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "SkullOwner",
-                                    "target": "SkullOwner"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "note_block_sound",
-                                    "target": "BlockEntityTag.note_block_sound"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:profile",
+                                "minecraft:note_block_sound",
+                                "minecraft:custom_name"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/podzol.json
+++ b/ltos/data/minecraft/loot_tables/blocks/podzol.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/polished_tuff.json
+++ b/ltos/data/minecraft/loot_tables/blocks/polished_tuff.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/polished_tuff",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'polished_tuff'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/polished_tuff_slab.json
+++ b/ltos/data/minecraft/loot_tables/blocks/polished_tuff_slab.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/polished_tuff_slab",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'polished_tuff_slab'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/polished_tuff_stairs.json
+++ b/ltos/data/minecraft/loot_tables/blocks/polished_tuff_stairs.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/polished_tuff_stairs",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'polished_tuff_stairs'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/polished_tuff_wall.json
+++ b/ltos/data/minecraft/loot_tables/blocks/polished_tuff_wall.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/polished_tuff_wall",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'polished_tuff_wall'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/purple_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/purple_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/purple_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/purple_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:purple_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/purple_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/purple_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/purple_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/purple_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/red_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/red_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/red_mushroom_block.json
+++ b/ltos/data/minecraft/loot_tables/blocks/red_mushroom_block.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/red_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/red_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:red_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/red_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/red_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/red_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/red_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/redstone_ore.json
+++ b/ltos/data/minecraft/loot_tables/blocks/redstone_ore.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/sculk.json
+++ b/ltos/data/minecraft/loot_tables/blocks/sculk.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/sculk_catalyst.json
+++ b/ltos/data/minecraft/loot_tables/blocks/sculk_catalyst.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/sculk_sensor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/sculk_sensor.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/sculk_shrieker.json
+++ b/ltos/data/minecraft/loot_tables/blocks/sculk_shrieker.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/sculk_vein.json
+++ b/ltos/data/minecraft/loot_tables/blocks/sculk_vein.json
@@ -10,14 +10,16 @@
                         {
                             "condition": "minecraft:match_tool",
                             "predicate": {
-                                "enchantments": [
-                                    {
-                                        "enchantment": "minecraft:silk_touch",
-                                        "levels": {
-                                            "min": 1
+                                "predicates": {
+                                    "minecraft:enchantments": [
+                                        {
+                                            "enchantment": "minecraft:silk_touch",
+                                            "levels": {
+                                                "min": 1
+                                            }
                                         }
-                                    }
-                                ]
+                                    ]
+                                }
                             }
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/sea_lantern.json
+++ b/ltos/data/minecraft/loot_tables/blocks/sea_lantern.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/seagrass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/seagrass.json
@@ -7,9 +7,7 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "items": [
-                            "minecraft:shears"
-                        ]
+                        "items": "minecraft:shears"
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/short_grass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/short_grass.json
@@ -13,9 +13,7 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "items": [
-                                            "minecraft:shears"
-                                        ]
+                                        "items": "minecraft:shears"
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/small_amethyst_bud.json
+++ b/ltos/data/minecraft/loot_tables/blocks/small_amethyst_bud.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/small_dripleaf.json
+++ b/ltos/data/minecraft/loot_tables/blocks/small_dripleaf.json
@@ -7,9 +7,7 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "items": [
-                            "minecraft:shears"
-                        ]
+                        "items": "minecraft:shears"
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/smoker.json
+++ b/ltos/data/minecraft/loot_tables/blocks/smoker.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/snow.json
+++ b/ltos/data/minecraft/loot_tables/blocks/snow.json
@@ -184,14 +184,16 @@
                                     "term": {
                                         "condition": "minecraft:match_tool",
                                         "predicate": {
-                                            "enchantments": [
-                                                {
-                                                    "enchantment": "minecraft:silk_touch",
-                                                    "levels": {
-                                                        "min": 1
+                                            "predicates": {
+                                                "minecraft:enchantments": [
+                                                    {
+                                                        "enchantment": "minecraft:silk_touch",
+                                                        "levels": {
+                                                            "min": 1
+                                                        }
                                                     }
-                                                }
-                                            ]
+                                                ]
+                                            }
                                         }
                                     }
                                 }

--- a/ltos/data/minecraft/loot_tables/blocks/snow_block.json
+++ b/ltos/data/minecraft/loot_tables/blocks/snow_block.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/soul_campfire.json
+++ b/ltos/data/minecraft/loot_tables/blocks/soul_campfire.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/spruce_leaves.json
+++ b/ltos/data/minecraft/loot_tables/blocks/spruce_leaves.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
@@ -74,22 +74,22 @@
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "items": [
-                                        "minecraft:shears"
-                                    ]
+                                    "items": "minecraft:shears"
                                 }
                             },
                             {
                                 "condition": "minecraft:match_tool",
                                 "predicate": {
-                                    "enchantments": [
-                                        {
-                                            "enchantment": "minecraft:silk_touch",
-                                            "levels": {
-                                                "min": 1
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {
+                                                "enchantment": "minecraft:silk_touch",
+                                                "levels": {
+                                                    "min": 1
+                                                }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/ltos/data/minecraft/loot_tables/blocks/stone.json
+++ b/ltos/data/minecraft/loot_tables/blocks/stone.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/tall_grass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tall_grass.json
@@ -16,9 +16,7 @@
                     "offsetY": 1,
                     "predicate": {
                         "block": {
-                            "blocks": [
-                                "minecraft:tall_grass"
-                            ],
+                            "blocks": "minecraft:tall_grass",
                             "state": {
                                 "half": "upper"
                             }
@@ -36,9 +34,7 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "items": [
-                                            "minecraft:shears"
-                                        ]
+                                        "items": "minecraft:shears"
                                     }
                                 }
                             ],
@@ -84,9 +80,7 @@
                     "offsetY": -1,
                     "predicate": {
                         "block": {
-                            "blocks": [
-                                "minecraft:tall_grass"
-                            ],
+                            "blocks": "minecraft:tall_grass",
                             "state": {
                                 "half": "lower"
                             }
@@ -104,9 +98,7 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "items": [
-                                            "minecraft:shears"
-                                        ]
+                                        "items": "minecraft:shears"
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/tall_seagrass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tall_seagrass.json
@@ -7,9 +7,7 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "items": [
-                            "minecraft:shears"
-                        ]
+                        "items": "minecraft:shears"
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/trapped_chest.json
+++ b/ltos/data/minecraft/loot_tables/blocks/trapped_chest.json
@@ -13,7 +13,10 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name"
+                            ],
                             "source": "block_entity"
                         }
                     ],

--- a/ltos/data/minecraft/loot_tables/blocks/trial_spawner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/trial_spawner.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/trial_spawner",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'trial_spawner'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/tube_coral.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tube_coral.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/tube_coral_block.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tube_coral_block.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/tube_coral_fan.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tube_coral_fan.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/tuff_brick_slab.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tuff_brick_slab.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/tuff_brick_slab",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'tuff_brick_slab'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/tuff_brick_stairs.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tuff_brick_stairs.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/tuff_brick_stairs",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'tuff_brick_stairs'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/tuff_brick_wall.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tuff_brick_wall.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/tuff_brick_wall",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'tuff_brick_wall'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/tuff_bricks.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tuff_bricks.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/tuff_bricks",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'tuff_bricks'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/tuff_slab.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tuff_slab.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/tuff_slab",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'tuff_slab'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/tuff_stairs.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tuff_stairs.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/tuff_stairs",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'tuff_stairs'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/tuff_wall.json
+++ b/ltos/data/minecraft/loot_tables/blocks/tuff_wall.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/tuff_wall",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'tuff_wall'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/turtle_egg.json
+++ b/ltos/data/minecraft/loot_tables/blocks/turtle_egg.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/twisting_vines.json
+++ b/ltos/data/minecraft/loot_tables/blocks/twisting_vines.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]

--- a/ltos/data/minecraft/loot_tables/blocks/twisting_vines_plant.json
+++ b/ltos/data/minecraft/loot_tables/blocks/twisting_vines_plant.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]

--- a/ltos/data/minecraft/loot_tables/blocks/vault.json
+++ b/ltos/data/minecraft/loot_tables/blocks/vault.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/vault",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'vault'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/vine.json
+++ b/ltos/data/minecraft/loot_tables/blocks/vine.json
@@ -7,9 +7,7 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "items": [
-                            "minecraft:shears"
-                        ]
+                        "items": "minecraft:shears"
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/warped_nylium.json
+++ b/ltos/data/minecraft/loot_tables/blocks/warped_nylium.json
@@ -13,14 +13,16 @@
                                 {
                                     "condition": "minecraft:match_tool",
                                     "predicate": {
-                                        "enchantments": [
-                                            {
-                                                "enchantment": "minecraft:silk_touch",
-                                                "levels": {
-                                                    "min": 1
+                                        "predicates": {
+                                            "minecraft:enchantments": [
+                                                {
+                                                    "enchantment": "minecraft:silk_touch",
+                                                    "levels": {
+                                                        "min": 1
+                                                    }
                                                 }
-                                            }
-                                        ]
+                                            ]
+                                        }
                                     }
                                 }
                             ],

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_chiseled_copper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_chiseled_copper",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_chiseled_copper'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_copper_bulb.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_copper_bulb",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_copper_bulb'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_copper_door.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_copper_door.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_copper_door",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_copper_door'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_copper_grate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_copper_grate.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_copper_grate",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_copper_grate'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_copper_trapdoor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_copper_trapdoor",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_copper_trapdoor'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_chiseled_copper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_exposed_chiseled_copper",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_exposed_chiseled_copper'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_copper_bulb.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_exposed_copper_bulb",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_exposed_copper_bulb'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_copper_door.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_copper_door.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_exposed_copper_door",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_exposed_copper_door'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_copper_grate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_copper_grate.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_exposed_copper_grate",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_exposed_copper_grate'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_copper_trapdoor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_exposed_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_exposed_copper_trapdoor",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_exposed_copper_trapdoor'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_chiseled_copper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_oxidized_chiseled_copper",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_oxidized_chiseled_copper'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_copper_bulb.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_oxidized_copper_bulb",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_oxidized_copper_bulb'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_copper_door.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_copper_door.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_oxidized_copper_door",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_oxidized_copper_door'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_copper_grate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_copper_grate.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_oxidized_copper_grate",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_oxidized_copper_grate'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_copper_trapdoor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_oxidized_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_oxidized_copper_trapdoor",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_oxidized_copper_trapdoor'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_chiseled_copper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_weathered_chiseled_copper",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_weathered_chiseled_copper'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_copper_bulb.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_weathered_copper_bulb",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_weathered_copper_bulb'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_copper_door.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_copper_door.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_weathered_copper_door",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_weathered_copper_door'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_copper_grate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_copper_grate.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_weathered_copper_grate",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_weathered_copper_grate'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_copper_trapdoor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/waxed_weathered_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/waxed_weathered_copper_trapdoor",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'waxed_weathered_copper_trapdoor'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/weathered_chiseled_copper.json
+++ b/ltos/data/minecraft/loot_tables/blocks/weathered_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/weathered_chiseled_copper",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'weathered_chiseled_copper'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/weathered_copper_bulb.json
+++ b/ltos/data/minecraft/loot_tables/blocks/weathered_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/weathered_copper_bulb",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'weathered_copper_bulb'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/weathered_copper_door.json
+++ b/ltos/data/minecraft/loot_tables/blocks/weathered_copper_door.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/weathered_copper_door",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'weathered_copper_door'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/weathered_copper_grate.json
+++ b/ltos/data/minecraft/loot_tables/blocks/weathered_copper_grate.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/weathered_copper_grate",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'weathered_copper_grate'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/weathered_copper_trapdoor.json
+++ b/ltos/data/minecraft/loot_tables/blocks/weathered_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "random_sequence": "minecraft:blocks/weathered_copper_trapdoor",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "ltos:data",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_custom_data",
+                            "tag": "{block:'weathered_copper_trapdoor'}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ltos/data/minecraft/loot_tables/blocks/weeping_vines.json
+++ b/ltos/data/minecraft/loot_tables/blocks/weeping_vines.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]

--- a/ltos/data/minecraft/loot_tables/blocks/weeping_vines_plant.json
+++ b/ltos/data/minecraft/loot_tables/blocks/weeping_vines_plant.json
@@ -16,22 +16,22 @@
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "items": [
-                                                    "minecraft:shears"
-                                                ]
+                                                "items": "minecraft:shears"
                                             }
                                         },
                                         {
                                             "condition": "minecraft:match_tool",
                                             "predicate": {
-                                                "enchantments": [
-                                                    {
-                                                        "enchantment": "minecraft:silk_touch",
-                                                        "levels": {
-                                                            "min": 1
+                                                "predicates": {
+                                                    "minecraft:enchantments": [
+                                                        {
+                                                            "enchantment": "minecraft:silk_touch",
+                                                            "levels": {
+                                                                "min": 1
+                                                            }
                                                         }
-                                                    }
-                                                ]
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]

--- a/ltos/data/minecraft/loot_tables/blocks/white_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/white_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/white_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/white_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:white_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/white_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/white_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/white_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/white_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/yellow_banner.json
+++ b/ltos/data/minecraft/loot_tables/blocks/yellow_banner.json
@@ -13,17 +13,12 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Patterns",
-                                    "target": "BlockEntityTag.Patterns"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:item_name",
+                                "minecraft:hide_additional_tooltip",
+                                "minecraft:banner_patterns"
                             ],
                             "source": "block_entity"
                         }

--- a/ltos/data/minecraft/loot_tables/blocks/yellow_shulker_box.json
+++ b/ltos/data/minecraft/loot_tables/blocks/yellow_shulker_box.json
@@ -8,39 +8,14 @@
                     "type": "minecraft:item",
                     "functions": [
                         {
-                            "function": "minecraft:copy_name",
-                            "source": "block_entity"
-                        },
-                        {
-                            "function": "minecraft:copy_custom_data",
-                            "ops": [
-                                {
-                                    "op": "replace",
-                                    "source": "Lock",
-                                    "target": "BlockEntityTag.Lock"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTable",
-                                    "target": "BlockEntityTag.LootTable"
-                                },
-                                {
-                                    "op": "replace",
-                                    "source": "LootTableSeed",
-                                    "target": "BlockEntityTag.LootTableSeed"
-                                }
+                            "function": "minecraft:copy_components",
+                            "include": [
+                                "minecraft:custom_name",
+                                "minecraft:container",
+                                "minecraft:lock",
+                                "minecraft:container_loot"
                             ],
                             "source": "block_entity"
-                        },
-                        {
-                            "type": "minecraft:shulker_box",
-                            "entries": [
-                                {
-                                    "type": "minecraft:dynamic",
-                                    "name": "minecraft:contents"
-                                }
-                            ],
-                            "function": "minecraft:set_contents"
                         }
                     ],
                     "name": "minecraft:yellow_shulker_box"

--- a/ltos/data/minecraft/loot_tables/blocks/yellow_stained_glass.json
+++ b/ltos/data/minecraft/loot_tables/blocks/yellow_stained_glass.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],

--- a/ltos/data/minecraft/loot_tables/blocks/yellow_stained_glass_pane.json
+++ b/ltos/data/minecraft/loot_tables/blocks/yellow_stained_glass_pane.json
@@ -7,14 +7,16 @@
                 {
                     "condition": "minecraft:match_tool",
                     "predicate": {
-                        "enchantments": [
-                            {
-                                "enchantment": "minecraft:silk_touch",
-                                "levels": {
-                                    "min": 1
+                        "predicates": {
+                            "minecraft:enchantments": [
+                                {
+                                    "enchantment": "minecraft:silk_touch",
+                                    "levels": {
+                                        "min": 1
+                                    }
                                 }
-                            }
-                        ]
+                            ]
+                        }
                     }
                 }
             ],


### PR DESCRIPTION
So, I kinda forgot to run a script and then everything seemed to work so I figured whatever I forgot wasn't important. It was.