### PR TITLE
New damage sources and air item model

### DIFF
--- a/ltos/data/ltos/loot_table/data.json
+++ b/ltos/data/ltos/loot_table/data.json
@@ -14,7 +14,8 @@
 						{"function":"minecraft:copy_custom_data","source":"this","ops":[{"source":"Trident","target":"destroyer_tool","op":"replace"}],"conditions":[{"condition":"minecraft:entity_properties","entity":"this","predicate":{"type":"minecraft:trident"}}]},
 						{"function":"minecraft:copy_custom_data","source":"this","ops":[{"source":"HandItems[0]","target":"destroyer_tool","op":"replace"}],"conditions":[{"condition":"minecraft:inverted","term":{"condition":"minecraft:entity_properties","entity":"this","predicate":{"type":"minecraft:player"}}}]},
 						{"function":"minecraft:copy_custom_data","source":"this","ops":[{"source":"Item","target":"destroyer_tool","op":"replace"}],"conditions":[{"condition":"minecraft:inverted","term":{"condition":"minecraft:entity_properties","entity":"this","predicate":{"type":"minecraft:player"}}}]},
-						{"function":"minecraft:set_custom_data","tag":"{destroyed_by:'command'}","conditions":[{"condition":"minecraft:inverted","term":{"condition":"minecraft:entity_properties","entity":"this","predicate":{}}}]}
+						{"function":"minecraft:set_custom_data","tag":"{destroyed_by:'command'}","conditions":[{"condition":"minecraft:inverted","term":{"condition":"minecraft:entity_properties","entity":"this","predicate":{}}}]},
+                        {"function":"minecraft:set_components","components":{"minecraft:item_model": "minecraft:air"}}
 					]
 				}
 			]

--- a/ltos/data/ltos/loot_table/entity_data.json
+++ b/ltos/data/ltos/loot_table/entity_data.json
@@ -13,7 +13,8 @@
 						{"function": "minecraft:set_custom_data","tag": "{always_most_significant_fall:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:always_most_significant_fall","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{always_triggers_silverfish:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:always_triggers_silverfish","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{avoids_guardian_thorns:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:avoids_guardian_thorns","expected": true}]}}]},
-						{"function": "minecraft:set_custom_data","tag": "{burns_armor_stands:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:burns_armor_stands","expected": true}]}}]},
+						{"function": "minecraft:set_custom_data","tag": "{burn_from_stepping:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:burn_from_stepping","expected": true}]}}]},
+                        {"function": "minecraft:set_custom_data","tag": "{burns_armor_stands:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:burns_armor_stands","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{bypasses_armor:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:bypasses_armor","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{bypasses_effects:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:bypasses_effects","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{bypasses_enchantments:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:bypasses_enchantments","expected": true}]}}]},
@@ -21,6 +22,7 @@
 						{"function": "minecraft:set_custom_data","tag": "{bypasses_resistance:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:bypasses_resistance","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{bypasses_shield:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:bypasses_shield","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{bypasses_wolf_armor:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:bypasses_wolf_armor","expected": true}]}}]},
+						{"function": "minecraft:set_custom_data","tag": "{can_break_armor_stand:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:can_break_armor_stand","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{damages_helmet:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:damages_helmet","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{ignites_armor_stands:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:ignites_armor_stands","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{is_drowning:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:is_drowning","expected": true}]}}]},
@@ -31,9 +33,12 @@
 						{"function": "minecraft:set_custom_data","tag": "{is_lightning:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:is_lightning","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{is_player_attack:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:is_player_attack","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{is_projectile:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:is_projectile","expected": true}]}}]},
+						{"function": "minecraft:set_custom_data","tag": "{mace_smash:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:mace_smash","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{no_anger:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:no_anger","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{no_impact:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:no_impact","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{no_knockback:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:no_knockback","expected": true}]}}]},
+						{"function": "minecraft:set_custom_data","tag": "{panic_causes:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:panic_causes","expected": true}]}}]},
+						{"function": "minecraft:set_custom_data","tag": "{panic_environmental_causes:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:panic_environmental_causes","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{witch_resistant_to:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:witch_resistant_to","expected": true}]}}]},
 						{"function": "minecraft:set_custom_data","tag": "{wither_immune_to:'true'}","conditions": [{"condition": "minecraft:damage_source_properties","predicate": {"tags": [{"id": "minecraft:wither_immune_to","expected": true}]}}]},
 						{"function":"minecraft:copy_custom_data","source":"this","ops":[{"source":"Tags","target":"entity_tags","op":"replace"}]},
@@ -43,7 +48,8 @@
 						{"function":"minecraft:copy_custom_data","source":"attacker","ops":[{"source":"SelectedItem","target":"killer_weapon","op":"replace"}],"conditions":[{"condition":"minecraft:entity_properties","entity":"attacker","predicate":{"type":"minecraft:player"}}]},
 						{"function":"minecraft:copy_custom_data","source":"attacker","ops":[{"source":"Trident","target":"killer_weapon","op":"replace"}],"conditions":[{"condition":"minecraft:entity_properties","entity":"attacker","predicate":{"type":"minecraft:trident"}}]},
 						{"function":"minecraft:copy_custom_data","source":"attacker","ops":[{"source":"HandItems[0]","target":"killer_weapon","op":"replace"}],"conditions":[{"condition":"minecraft:inverted","term":{"condition":"minecraft:entity_properties","entity":"attacker","predicate":{"type":"minecraft:player"}}}]},
-						{"function":"minecraft:copy_custom_data","source":"attacker","ops":[{"source":"Item","target":"killer_weapon","op":"replace"}],"conditions":[{"condition":"minecraft:inverted","term":{"condition":"minecraft:entity_properties","entity":"attacker","predicate":{"type":"minecraft:player"}}}]}
+						{"function":"minecraft:copy_custom_data","source":"attacker","ops":[{"source":"Item","target":"killer_weapon","op":"replace"}],"conditions":[{"condition":"minecraft:inverted","term":{"condition":"minecraft:entity_properties","entity":"attacker","predicate":{"type":"minecraft:player"}}}]},
+                        {"function":"minecraft:set_components","components":{"minecraft:item_model": "minecraft:air"}}
 					]
 				}
 			]


### PR DESCRIPTION
I added the new damage types from 1.21.1-1.21.4 and, since it’s been a popular request, made the debug sticks use the item model for air. 

Seems to work properly when tested.